### PR TITLE
clarifying keeping message for #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function conflict (dest, opt) {
                 replaceAll = true;
                 /* falls through */
               case 'replace':
-                logFile('Keeping', file, stat);
+                logFile('Overwriting', file, stat);
                 this.push(file);
                 break;
               case 'skipAll':
@@ -65,7 +65,7 @@ module.exports = function conflict (dest, opt) {
           ask(file, askCb.bind(this));
         }.bind(this));
       } else {
-        logFile('Keeping', file, stat);
+        logFile('Creating', file, stat);
         this.push(file);
         cb();
       }


### PR DESCRIPTION
Simple text changes, let me know if for the `replaceAll` logic branch if we should indicate that it is a forced replace replace as `no conflict` is sorta misleading in that context.
