### PR TITLE
Allow configurable logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,21 @@ module.exports = function conflict (dest, opt) {
             error('Reading old file for comparison failed with: ' + err.message);
           }
           if (contents === String(file.contents)) {
-            logFile('Skipping', file, stat, '(identical)');
+            logFile({
+              message: 'Skipping',
+              file: file,
+              stat: stat,
+              extraText: '(identical)'
+            });
             return cb();
           }
 
           if (skipAll) {
-            logFile('Skipping', file, stat);
+            logFile({
+              message: 'Skipping',
+              file: file,
+              stat: stat
+            });
             return cb();
           }
 
@@ -41,21 +50,33 @@ module.exports = function conflict (dest, opt) {
                 replaceAll = true;
                 /* falls through */
               case 'replace':
-                logFile('Overwriting', file, stat);
+                logFile({
+                  message: 'Overwriting',
+                  file: file,
+                  stat: stat
+                });
                 this.push(file);
                 break;
               case 'skipAll':
                 skipAll = true;
                 /* falls through */
               case 'skip':
-                logFile('Skipping', file, stat);
+                logFile({
+                  message: 'Skipping',
+                  file: file,
+                  stat: stat
+                });
                 break;
               case 'end':
                 log(gutil.colors.red('Aborting...'));
                 process.exit(0);
                 break;
               case 'diff':
-                logFile('Showing diff for', file, stat);
+                logFile({
+                  message: 'Showing diff for',
+                  file: file,
+                  stat: stat
+                });
                 diffFiles(file, newPath);
                 ask(file, askCb.bind(this));
                 return;
@@ -65,7 +86,11 @@ module.exports = function conflict (dest, opt) {
           ask(file, askCb.bind(this));
         }.bind(this));
       } else {
-        logFile('Creating', file, stat);
+        logFile({
+          message: 'Creating',
+          file: file,
+          stat: stat
+        });
         this.push(file);
         cb();
       }
@@ -138,7 +163,15 @@ function colorFromPart (part) {
   return 'grey';
 }
 
-function logFile (message, file, stat, extraText) {
+/*
+ * Args: message, file, stat, extraText
+ */
+function logFile(options){
+  var message   = options.message,
+      file      = options.file,
+      stat      = options.stat,
+      extraText = options.extraText;
+
   if (!file || !file.relative || (stat && stat.isDirectory())) {
     return;
   }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function conflict (dest, opt) {
 
   var replaceAll = opt.replaceAll || false;
   var skipAll = opt.skipAll || false;
+  var logger = opt.logger || log;
 
   return through2.obj(function (file, enc, cb) {
     var newPath = path.resolve(opt.cwd || process.cwd(), dest, file.relative);
@@ -30,7 +31,8 @@ module.exports = function conflict (dest, opt) {
               message: 'Skipping',
               file: file,
               stat: stat,
-              extraText: '(identical)'
+              extraText: '(identical)',
+              logger: logger
             });
             return cb();
           }
@@ -39,7 +41,8 @@ module.exports = function conflict (dest, opt) {
             logFile({
               message: 'Skipping',
               file: file,
-              stat: stat
+              stat: stat,
+              logger: logger
             });
             return cb();
           }
@@ -53,7 +56,8 @@ module.exports = function conflict (dest, opt) {
                 logFile({
                   message: 'Overwriting',
                   file: file,
-                  stat: stat
+                  stat: stat,
+                  logger: logger
                 });
                 this.push(file);
                 break;
@@ -64,7 +68,8 @@ module.exports = function conflict (dest, opt) {
                 logFile({
                   message: 'Skipping',
                   file: file,
-                  stat: stat
+                  stat: stat,
+                  logger: logger
                 });
                 break;
               case 'end':
@@ -75,7 +80,8 @@ module.exports = function conflict (dest, opt) {
                 logFile({
                   message: 'Showing diff for',
                   file: file,
-                  stat: stat
+                  stat: stat,
+                  logger: logger
                 });
                 diffFiles(file, newPath);
                 ask(file, askCb.bind(this));
@@ -89,7 +95,8 @@ module.exports = function conflict (dest, opt) {
         logFile({
           message: 'Creating',
           file: file,
-          stat: stat
+          stat: stat,
+          logger: logger
         });
         this.push(file);
         cb();
@@ -170,16 +177,17 @@ function logFile(options){
   var message   = options.message,
       file      = options.file,
       stat      = options.stat,
-      extraText = options.extraText;
+      extraText = options.extraText,
+      logger    = options.logger;
 
   if (!file || !file.relative || (stat && stat.isDirectory())) {
     return;
   }
   var fileName = gutil.colors.magenta(file.relative);
   if (extraText) {
-    log(message, fileName, extraText);
+    logger(message, fileName, extraText);
   } else {
-    log(message, fileName);
+    logger(message, fileName);
   }
 }
 


### PR DESCRIPTION
This fixes #4 by allowing the configuration of the logger function via the options. I didn't add unit tests, but the current tests are still passing. If this is something you think is worth using, and you want it unit tested before merging, just let me know.